### PR TITLE
Add option for S3 output to be in structured JSON format

### DIFF
--- a/examples/example.s3-output.yml
+++ b/examples/example.s3-output.yml
@@ -34,6 +34,7 @@ outputs:
         s3_path: "path-in-bucket-to-put-the-file"
         time_slice_format: "%Y-%m-%d/%H%M"
         aws_s3_output_key: "%{path}/%{timeSlice}/%{hostname}_%{uuid}.gz"
+        output_format: json
 
 routes:
   - route1:


### PR DESCRIPTION
Our use-case requires the other Filebeat-added fields to be present.  This commit adds the `output_format: json`  option to the S3 output config to cater for this.