### PR TITLE
Make JSON offset field optional

### DIFF
--- a/input/filebeat/parser.go
+++ b/input/filebeat/parser.go
@@ -165,8 +165,12 @@ func (p *Parser) read() (uint32, error) {
 				return seq, err
 			}
 			ev.Source = fmt.Sprintf("lumberjack://%s%s", fields["host"], fields["file"])
-			jsonNumber := fields["offset"].(json.Number)
-			ev.Offset, _ = jsonNumber.Int64()
+
+			if fields["offset"] != nil {
+				jsonNumber := fields["offset"].(json.Number)
+				ev.Offset, _ = jsonNumber.Int64()
+			}
+
 			ev.Line = uint64(seq)
 			t := fields["message"].(string)
 			ev.Text = &t


### PR DESCRIPTION
Currently, Logzoom will crash if the offset field isn't set (which is the case when using Journalbeat as an input).  This makes the field optional to stop that from happening.