### PR TITLE
Add support for adding an SCL to S3 uploads

### DIFF
--- a/examples/example.s3-output.yml
+++ b/examples/example.s3-output.yml
@@ -34,6 +34,7 @@ outputs:
         s3_path: "path-in-bucket-to-put-the-file"
         time_slice_format: "%Y-%m-%d/%H%M"
         aws_s3_output_key: "%{path}/%{timeSlice}/%{hostname}_%{uuid}.gz"
+        aws_s3_output_acl: "bucket-owner-full-control"
         output_format: json
 
 routes:

--- a/output/s3/s3.go
+++ b/output/s3/s3.go
@@ -54,6 +54,7 @@ type Config struct {
 	Path            string `yaml:"s3_path"`
 	TimeSliceFormat string `yaml:"time_slice_format"`
 	AwsS3OutputKey  string `yaml:"aws_s3_output_key"`
+	AwsS3OutputACL  string `yaml:"aws_s3_output_acl,omitempty"`
 	SampleSize      *int   `yaml:"sample_size,omitempty"`
 	OutputFormat    string `yaml:"output_format,omitempty"`
 }
@@ -150,6 +151,7 @@ func (s3Writer *S3Writer) doUpload(fileInfo OutputFileInfo) error {
 		Bucket:          aws.String(s3Writer.Config.AwsS3Bucket),
 		Key:             aws.String(destFile),
 		ContentEncoding: aws.String("gzip"),
+		ACL:             aws.String(s3Writer.Config.AwsS3OutputACL),
 	})
 
 	if s3Error == nil {


### PR DESCRIPTION
Adds the aws_s3_output_acl option for setting an object ACL on logs uploaded to S3.  If left blank, AWS defaults to "private".